### PR TITLE
Map起動時に現在地から始まるようにする

### DIFF
--- a/app/src/main/java/com/haruta/harutyan/originalapp/AddLocationActivity.kt
+++ b/app/src/main/java/com/haruta/harutyan/originalapp/AddLocationActivity.kt
@@ -27,6 +27,14 @@ class AddLocationActivity : AppCompatActivity(), OnMapReadyCallback {
     }
 
     override fun onMapReady(googleMap: GoogleMap) {
+        val nagoya = LatLng( 35.1814,136.9063)
+        //起動時の表示場所を設定
+        googleMap.moveCamera(CameraUpdateFactory.newLatLng(nagoya))
+        //起動時の縮尺を設定
+        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(nagoya,15f))
+        //拡大・縮小ボタンを表示
+        googleMap.uiSettings.isZoomControlsEnabled = true
+
         //長押しされた時のActionを指示
         googleMap.setOnMapClickListener { longpushLocation: LatLng ->
             var newlocation = LatLng(longpushLocation.latitude, longpushLocation.longitude)


### PR DESCRIPTION
[Notion](https://www.notion.so/lifeistech/Map-59c0ee9861a44f44822eff53bfde23a3?pvs=4)

# 実装したこと
・Mapの起動時、表示画面を名古屋にする
・地図をより拡大した状態で起動させる
・拡大・縮小ボタンの設置

# 今後やること
起動画面を現在地に変える
` val nagoya = LatLng( 35.1814,136.9063)`
`googleMap.moveCamera(CameraUpdateFactory.newLatLng(nagoya))`
`nagoya`を現在地を宣言した関数に変える