### PR TITLE
地図を長押ししたときにピンを表示

### DIFF
--- a/app/src/main/java/com/haruta/harutyan/originalapp/AddLocationActivity.kt
+++ b/app/src/main/java/com/haruta/harutyan/originalapp/AddLocationActivity.kt
@@ -12,6 +12,7 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import com.haruta.harutyan.originalapp.PermissionUtils.PermissionDeniedDialog.Companion.newInstance
 import com.haruta.harutyan.originalapp.PermissionUtils.isPermissionGranted
@@ -24,6 +25,7 @@ class AddLocationActivity : AppCompatActivity(),
 
     private lateinit var binding: ActivityAddLocationBinding
     private lateinit var map: GoogleMap
+    private var marker: Marker? = null
     lateinit var db: AppDatabase
 
     private var permissionDenied = false
@@ -57,9 +59,7 @@ class AddLocationActivity : AppCompatActivity(),
 
             finish()
         }
-
     }
-
 
     override fun onMapReady(googleMap: GoogleMap) {
         //初期化の遅延
@@ -79,19 +79,21 @@ class AddLocationActivity : AppCompatActivity(),
         googleMap.uiSettings.isZoomControlsEnabled = true
 
         //エミュレーターでピンが打ちづらいので、あらかじめ設定。リリース時には消す
-        googleMap.addMarker(
-            MarkerOptions()
-                .position(nagoya)
-        )
-
+        // googleMap.addMarker(
+        //     MarkerOptions()
+        //         .position(nagoya)
+        // )
 
         //長押しされた時のActionを指示
-        googleMap.setOnMapClickListener { longpushLocation: LatLng ->
+        googleMap.setOnMapLongClickListener { longpushLocation: LatLng ->
+            marker?.remove()
+
             val newlocation = LatLng(longpushLocation.latitude, longpushLocation.longitude)
-            googleMap.addMarker(
+            marker = googleMap.addMarker(
                 MarkerOptions().position(newlocation)
             )
-            googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(newlocation, 14f))
+
+            //googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(newlocation, 1f))
         }
 
         //ピンのクリックを取得
@@ -99,7 +101,6 @@ class AddLocationActivity : AppCompatActivity(),
             latitude = it.latitude
             longitude = it.longitude
         }
-
     }
 
     private fun enableMyLocation() {
@@ -196,6 +197,5 @@ class AddLocationActivity : AppCompatActivity(),
 
     companion object {
         private const val LOCATION_PERMISSION_REQUEST_CODE = 1
-
     }
 }


### PR DESCRIPTION
# やったこと

地図を長押ししたときにピンを表示できるようにした

# 実装方法

- GoogleMap#addMarker で返り値 Marker が返されるので、それを Activity で保持
- Marker を作成する前に前に表示していた Marker を削除するようにした

# 動作

<video src="https://user-images.githubusercontent.com/49048577/223043717-66834465-634f-4c06-b5d4-befac7e51622.mp4" width="300px" ></ video>

